### PR TITLE
Remove 9418 port from start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
 # Starts both containers in  daemon mode
 docker rm -f gerrit && docker rm -f jenkins
-docker run -d -h gerrit -p 8080:8080 -p 29418:29418 -p 9418:9418 --name gerrit jenkins-gerrit-wfdemo-gerrit:1.0
+docker run -d -h gerrit -p 8080:8080 -p 29418:29418 --name gerrit jenkins-gerrit-wfdemo-gerrit:1.0
 docker run -d -h jenkins -p 8081:8080 --name jenkins --link gerrit:gerrit jenkins-gerrit-wfdemo-jenkins:1.0


### PR DESCRIPTION
As Gerrit is using port 29418, there is no need to use 9418 here
