### PR TITLE
Jenkins Maven update and Gerrit apt-get update

### DIFF
--- a/gerrit/Dockerfile
+++ b/gerrit/Dockerfile
@@ -2,7 +2,8 @@ FROM gerritforge/gerrit-ubuntu15.04:2.11.3
 MAINTAINER svanoort
 
 USER root
-RUN apt-get install -y curl python net-tools && \
+RUN apt-get update && \
+    apt-get install -y curl python net-tools && \
     rm -rf /var/lib/apt/lists/*
 RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /bin/repo \
     && chmod a+x /bin/repo

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -13,7 +13,7 @@ RUN curl https://storage.googleapis.com/git-repo-downloads/repo > /bin/repo \
     && chmod a+x /bin/repo
 
 # Maven install
-ENV MAVEN_VERSION 3.3.1
+ENV MAVEN_VERSION 3.3.9
 RUN cd /usr/local; wget -O - http://mirrors.ibiblio.org/apache/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xvzf -
 RUN ln -sv /usr/local/apache-maven-$MAVEN_VERSION /usr/local/maven
 


### PR DESCRIPTION
Updating Jenkins Maven version to 3.3.9, since 3.3.1 is no longer available from mirrors.ibiblio.org.

Updating Gerrit Dockerfile to run apt-get update to refresh package list, since base image Jenkins:1.609.2 package list is no longer valid.
